### PR TITLE
data: URIs not working since NoScript 2.6.9.20rc1

### DIFF
--- a/xpi/chrome/content/noscript/Policy.js
+++ b/xpi/chrome/content/noscript/Policy.js
@@ -557,11 +557,6 @@ const MainContentPolicy = {
                       return this.reject("Drop XSS", arguments);
                     }            
                   }
-                } else if (
-                  !(aContext.ownerDocument.URL === originURL // Addon-SDK panels
-                     || this.isJSEnabled(originSite = this.getSite(originURL)))
-                  ) {
-                  return this.reject("top level data: URI from forbidden origin", arguments);
                 }
               }
               return CP_OK; // JavaScript execution policies will take care of this


### PR DESCRIPTION
Quick & dirty fix by removing "else if" code block that breaks data: URIs since NoScript 2.6.9.20rc1 (released on March 28, 2015). I shared the bug a month ago and it's still not fixed so here is a fork. It may take some time to be merged in the official release: https://forums.informaction.com/viewtopic.php?f=10&t=20898
