### PR TITLE
[PR1] NoScript: RequestPolicy

### DIFF
--- a/xpi/chrome/content/noscript/Main.js
+++ b/xpi/chrome/content/noscript/Main.js
@@ -237,6 +237,7 @@ const ns = {
   forbidFlash: true,
   forbidPlugins: true,
   forbidMedia: true,
+  forbidImages: false,
   forbidFonts: true,
   forbidWebGL: false,
   forbidIFrames: false,
@@ -353,6 +354,7 @@ const ns = {
       case "forbidSilverlight":
       case "forbidPlugins":
       case "forbidMedia":
+      case "forbidImages":
       case "forbidFonts":
       case "forbidWebGL":
       case "forbidIFrames":
@@ -360,7 +362,7 @@ const ns = {
         this[name]=this.getPref(name, this[name]);
         this.forbidSomeContent = this.forbidJava || this.forbidFlash ||
           this.forbidSilverlight || this.forbidPlugins ||
-          this.forbidMedia || this.forbidFonts ||
+          this.forbidMedia || this.forbidImages || this.forbidFonts ||
           this.forbidIFrames || this.forbidFrames;
       break;
 
@@ -730,7 +732,8 @@ const ns = {
       "filterXPost", "filterXGet",
       "filterXGetRx", "filterXGetUserRx",
       "filterXExceptions",
-      "forbidJava", "forbidFlash", "forbidSilverlight", "forbidPlugins", "forbidMedia", "forbidFonts", "forbidWebGL",
+      "forbidJava", "forbidFlash", "forbidSilverlight", "forbidPlugins",
+      "forbidMedia", "forbidImages", "forbidFonts", "forbidWebGL",
       "forbidIFrames", "forbidIFramesContext", "forbidFrames",
       "forbidMetaRefresh",
       "forbidXBL", "forbidXHR",
@@ -751,7 +754,8 @@ const ns = {
       "allowHttpsOnly",
       "truncateTitle", "truncateTitleLen",
       "whitelistRegExp", "proxiedDNS", "asyncNetworking",
-      "fakeScriptLoadEvents.enabled", "fakeScriptLoadEvents.onlyRequireJS", "fakeScriptLoadEvents.exceptions", "fakeScriptLoadEvents.docExceptions",
+      "fakeScriptLoadEvents.enabled", "fakeScriptLoadEvents.onlyRequireJS",
+      "fakeScriptLoadEvents.exceptions", "fakeScriptLoadEvents.docExceptions",
       "restrictSubdocScripting", "cascadePermissions", "globalHttpsWhitelist"
       ]) {
       try {

--- a/xpi/chrome/content/noscript/MainChild.js
+++ b/xpi/chrome/content/noscript/MainChild.js
@@ -558,18 +558,62 @@ var MainChild = {
 
   cpConsoleFilter: [2, 5, 6, 7, 15],
   cpDump: function(msg, aContentType, aContentLocation, aRequestOrigin, aContext, aMimeTypeGuess, aInternalCall, aPrincipal) {
-    this.dump("Content " + msg + " -- type: " + aContentType + ", location: " + (aContentLocation && aContentLocation.spec) +
-      ", requestOrigin: " + (aRequestOrigin && aRequestOrigin.spec) + ", ctx: " +
-        ((aContext instanceof Ci.nsIDOMHTMLElement) ? "<HTML " + aContext.tagName + ">" // try not to cause side effects of toString() during load
-          : aContext)  +
-        ", mime: " + aMimeTypeGuess + ", Internal: " + aInternalCall +
-        ", principal.origin: " + (aPrincipal && aPrincipal.origin));
+    var aContentTypeName = aContentType ? "TYPE(" + aContentType + ")" : "UNKNOWN";
+    switch (aContentType) {
+      case 1: aContentTypeName = "OTHER"; break;
+      case 2: aContentTypeName = "SCRIPT"; break;
+      case 3: aContentTypeName = "IMAGE"; break;
+      case 4: aContentTypeName = "STYLESHEET"; break;
+      case 5: aContentTypeName = "OBJECT"; break;
+      case 6: aContentTypeName = "DOCUMENT"; break;
+      case 7: aContentTypeName = "SUBDOCUMENT"; break;
+      case 8: aContentTypeName = "REFRESH"; break;
+      case 9: aContentTypeName = "XBL"; break;
+      case 10: aContentTypeName = "PING"; break;
+      case 11: aContentTypeName = "XMLHTTPREQUEST"; break;
+      case 12: aContentTypeName = "OBJECT_SUBREQUEST"; break;
+      case 13: aContentTypeName = "DTD"; break;
+      case 14: aContentTypeName = "FONT"; break;
+      case 15: aContentTypeName = "MEDIA"; break;
+      case 16: aContentTypeName = "WEBSOCKET"; break;
+      case 17: aContentTypeName = "CSP_REPORT"; break;
+      case 18: aContentTypeName = "XSLT"; break;
+      case 19: aContentTypeName = "BEACON"; break;
+      case 20: aContentTypeName = "FETCH"; break;
+      case 21: aContentTypeName = "IMAGESET"; break;
+    }
+    this.dump("Content " + msg 
+      + ": " + aContentTypeName
+      + ", location: " + (aContentLocation && aContentLocation.spec)
+      + ", ctx: " + ((aContext instanceof Ci.nsIDOMHTMLElement)
+         ? "<HTML " + aContext.tagName + ">" // try not to cause side effects of toString() during load
+         : aContext)
+      + (aInternalCall ? ", Internal: " + aInternalCall : "")
+      + (aMimeTypeGuess ? ", mime: " + aMimeTypeGuess : "")
+      + ", principal.origin: " + (aPrincipal && aPrincipal.origin)
+      + ", requestOrigin: " + (aRequestOrigin && aRequestOrigin.spec)
+    );
   },
+
+  allow: function(what, args /* [aContentType, aContentLocation, aRequestOrigin, aContext, aMimeTypeGuess, aInternalCall, [aPrincipal] ] */) {
+
+    if (this.consoleDump) {
+      if(this.consoleDump & LOG_CONTENT_BLOCK && args.length >= 6) {
+        this.cpDump("allowed" + (what ? " " + what : ""), args[0], args[1], args[2], args[3], args[4], args[5], args[6] && args[6]);
+      }
+      if(this.consoleDump & LOG_CONTENT_CALL) {
+        this.dump(new Error().stack);
+      }
+    }
+
+    return CP_OK;
+  },
+
   reject: function(what, args /* [aContentType, aContentLocation, aRequestOrigin, aContext, aMimeTypeGuess, aInternalCall, [aPrincipal] ] */) {
 
     if (this.consoleDump) {
       if(this.consoleDump & LOG_CONTENT_BLOCK && args.length >= 6) {
-        this.cpDump("BLOCKED " + what, args[0], args[1], args[2], args[3], args[4], args[5], args[6] && args[6]);
+        this.cpDump("BLOCKED" + (what ? " " + what : ""), args[0], args[1], args[2], args[3], args[4], args[5], args[6] && args[6]);
       }
       if(this.consoleDump & LOG_CONTENT_CALL) {
         this.dump(new Error().stack);

--- a/xpi/defaults/preferences/noscript.js
+++ b/xpi/defaults/preferences/noscript.js
@@ -46,6 +46,7 @@ pref("noscript.forbidFlash", true);
 pref("noscript.forbidSilverlight", true);
 pref("noscript.forbidPlugins", true);
 pref("noscript.forbidMedia", true);
+pref("noscript.forbidImages", false);
 pref("noscript.forbidFonts", true);
 pref("noscript.forbidWebGL", false);
 pref("noscript.forbidActiveContentParentTrustCheck", true);


### PR DESCRIPTION
This is a PR for noscript; knowing this won't be pulled. **I do want** Giorgio Maone to try this!
(Just `git clone https://github.com/metadings/noscript metadings-noscript`, `cd metadings-noscript`, then `git checkout master-requestpolicy` to run `makexpi.sh`, trying this AddOn in your favorite Mozilla Firefox installation.)

## NoScript: RequestPolicy

Changes in Policy.js

This is now doing "CP PASS 1": let the `switch (aContentType)` flow through `TYPE_DOCUMENT`, just trying tagesschau.de requests, also on HTMLs, STYLESHEETs, IMAGEs and SCRIPTs.
This now doesn't do sitestat.com or ioam.de. I may do now ard.de, or sportschau.de.
This is also why I'm going to call this NoScript+RequestPolicy.
This also adds TYPE_IMAGESET, as I see many of them on `wikipedia.org`, where you should allow `wikimedia.org`.

For example, if you go to `www.spiegel.de`, this ALLOWs to also request `spiegel.de`, `cdn1.spiegel.de`, `count.spiegel.de` and BLOCKs requesting `script.ioam.de`, `imagesrv.adition.com`, `static.parsely.com`, `s290.mxcdn.net`, `www.google-analytics.com` and `a.visualrevenue.com`.

For example, if you go to `arstechnica.co.uk`, you should also allow `arstechnica.net`. This ALLOWs to request `cdn.arstechnica.net` and BLOCKs requesting `condenast-d.openx.net`, `www.googletagservices.com`, `s.skimresources.com`, `sb.scorecardresearch.com`, `www.google-analytics.com`, `d1z2jf7jlzjs58.cloudfront.net`, `dwgyu36up6iuz.cloudfront.net` and `js-agent.newrelic.com`.

- Main.js, defaults/preferences/noscript.js: Just adding forbidImages to noscript. (There should be a MenuItem or a CheckBox to allow easily changing this preference...)

- MainChild.js: Adding function `allow`, to also see when requests are allowed. Also adds a `switch (aContentType)`, to have a name like IMAGE instead of 3, or a name like IMAGESET instead of 21.